### PR TITLE
Refactor README to professional layout and keep only live-demo projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,70 @@
 <div align="center">
 
-# <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="45"/> Hello, I'm Sunil Kumar
+# Sunil Kumar
 
-<img src="https://readme-typing-svg.demolab.com?font=Orbitron&weight=700&size=34&duration=2500&pause=800&color=38BDF8&center=true&vCenter=true&multiline=true&repeat=true&width=1000&height=120&lines=🚀+Full+Stack+MERN+Developer;🤖+AI+%26+Machine+Learning+Engineer;💻+Competitive+Programmer;⚡+Building+Scalable+Applications;🔥+800%2B+DSA+Problems+Solved" />
+**Full Stack (MERN) Developer | AI/ML Enthusiast**  
+B.Tech CSE, PDPM IIITDM Jabalpur (2022–2026)
 
-<br/>
-
-<img src="https://img.shields.io/badge/Focus-Full%20Stack%20%26%20AI-blueviolet?style=for-the-badge" />
-<img src="https://img.shields.io/badge/Open%20To-Internships%20%26%20SDE%20Roles-success?style=for-the-badge" />
-
-<br/><br/>
-
-<img src="https://komarev.com/ghpvc/?username=ankitsunil530&label=PROFILE+VIEWS&color=0e75b6&style=for-the-badge"/>
-
-<img src="https://img.shields.io/github/followers/ankitsunil530?style=for-the-badge&logo=github&color=7c3aed"/>
-
-<img src="https://img.shields.io/github/stars/ankitsunil530?style=for-the-badge&logo=github&color=f59e0b"/>
+<a href="https://www.linkedin.com/in/sunil-kumar-549595225/"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white"/></a>
+<a href="https://github.com/ankitsunil530"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white"/></a>
+<a href="mailto:ankitsunil530@gmail.com"><img src="https://img.shields.io/badge/Email-EA4335?style=for-the-badge&logo=gmail&logoColor=white"/></a>
+<a href="https://codolio.com/profile/ankitsunil530"><img src="https://img.shields.io/badge/Portfolio-111827?style=for-the-badge&logo=firefox&logoColor=white"/></a>
 
 </div>
 
 ---
 
-# 💫 About Me
-
-<img align="right" width="320" src="https://media.giphy.com/media/coxQHKASG60HrHtvkt/giphy.gif"/>
-
-🎓 B.Tech CSE Student at **IIITDM Jabalpur**  
-
-🚀 Full Stack Developer specialized in **MERN Stack Development**  
-
-🤖 AI/ML Enthusiast working with **TensorFlow, CNN & NLP**  
-
-💡 Passionate about building scalable real-world applications  
-
-🧠 Solved **800+ DSA Problems** across coding platforms  
-
-⚡ Open Source Contributor & Tech Explorer  
-
-📍 Lucknow, Uttar Pradesh  
+## Professional Summary
+- Full Stack Developer with hands-on experience in building end-to-end MERN applications.
+- Strong foundation in Data Structures & Algorithms (800+ problems solved).
+- Built and deployed AI/ML projects using TensorFlow, Scikit-learn, and Streamlit.
+- Interested in Software Development Engineer (SDE) and full stack roles.
 
 ---
 
-# 🛠️ Tech Stack
-
-<div align="center">
-
-### 👨‍💻 Languages
-<img src="https://skillicons.dev/icons?i=cpp,c,java,python,javascript" />
-
-<br/><br/>
-
-### 🌐 Frontend
-<img src="https://skillicons.dev/icons?i=react,redux,html,css,tailwind,bootstrap" />
-
-<br/><br/>
-
-### ⚙️ Backend
-<img src="https://skillicons.dev/icons?i=nodejs,express,mongodb,postgresql" />
-
-<br/><br/>
-
-### 🤖 AI / Machine Learning
-<img src="https://skillicons.dev/icons?i=tensorflow,opencv" />
-
-<br/><br/>
-
-### ☁️ Tools & Platforms
-<img src="https://skillicons.dev/icons?i=git,github,docker,postman,gcp,vscode" />
-
-</div>
+## Technical Skills
+- **Languages:** C++, C, Java, Python, JavaScript
+- **Frontend:** React.js, Redux Toolkit, HTML, CSS, Tailwind CSS, Bootstrap
+- **Backend:** Node.js, Express.js, MongoDB, PostgreSQL, REST APIs
+- **AI/ML:** TensorFlow, CNN, Scikit-learn, OpenCV
+- **Tools:** Git, GitHub, Docker, Postman, VS Code
 
 ---
 
-# 🚀 Freelancing Projects
+## Projects (Live)
+> नीचे सिर्फ वही projects रखे गए हैं जिनके live links उपलब्ध हैं।
 
-<div align="center">
-
-| 💼 Project | ⚙️ Tech Stack | 🔗 GitHub Repository | 🌐 Live Demo |
+| Project | Tech Stack | Repository | Live Demo |
 |---|---|---|---|
-| 👕 Faith & Fast E-Commerce | MERN, JWT, Razorpay | [GitHub](https://github.com/ankitsunil530/FF) | [Live](https://ff-frontend.vercel.app/) |
-| 🍕 Pizza Customization Web App | MERN, Redux Toolkit | [GitHub](https://github.com/ankitsunil530/Pizza-Customization-Web-App) | [Live](https://pizza-customization-web-app.vercel.app/) |
-
-</div>
-
----
-
-# 🤖 AI / ML Projects
-
-<div align="center">
-
-| 🧠 Project | ⚙️ Technologies | 🔗 GitHub Repository | 🌐 Live Demo |
-|---|---|---|---|
-| 🩸 Blood Cell Classification | CNN, TensorFlow, Python | [GitHub](https://github.com/ankitsunil530/blood-cell-classification) | [Live](https://blood-cell-classification.streamlit.app/) |
-| 🌱 AI Cancer & Plant Disease Detection | CNN, React, Flask | [GitHub](https://github.com/ankitsunil530/AI-Cancer-and-Plant-Disease-Detection) | [Live](https://ai-cancer-and-plant-disease-detection.vercel.app/) |
-| 🛡️ Static Malware Detection | ML, Scikit-Learn | [GitHub](https://github.com/ankitsunil530/Static-Malware-Detection-) | [Live](https://static-malware-detection.streamlit.app/) |
-
-</div>
+| Faith & Fast E-Commerce | MERN, JWT, Razorpay | [GitHub](https://github.com/ankitsunil530/FF) | [Live](https://ff-frontend.vercel.app/) |
+| Pizza Customization Web App | MERN, Redux Toolkit | [GitHub](https://github.com/ankitsunil530/Pizza-Customization-Web-App) | [Live](https://pizza-customization-web-app.vercel.app/) |
+| Blood Cell Classification | CNN, TensorFlow, Python, Streamlit | [GitHub](https://github.com/ankitsunil530/blood-cell-classification) | [Live](https://blood-cell-classification.streamlit.app/) |
+| AI Cancer & Plant Disease Detection | CNN, React, Flask | [GitHub](https://github.com/ankitsunil530/AI-Cancer-and-Plant-Disease-Detection) | [Live](https://ai-cancer-and-plant-disease-detection.vercel.app/) |
+| Static Malware Detection | ML, Scikit-learn, Streamlit | [GitHub](https://github.com/ankitsunil530/Static-Malware-Detection-) | [Live](https://static-malware-detection.streamlit.app/) |
+| Task Management System | MERN, Redux Toolkit | [GitHub](https://github.com/ankitsunil530/Task-Management-System) | [Live](https://task-management-system-tawny-eta.vercel.app/) |
+| Banking Website | React.js, Tailwind CSS | [GitHub](https://github.com/ankitsunil530/Banking-Website) | [Live](https://banking-website-gamma.vercel.app/) |
+| Weather Knowing System | HTML, CSS, JavaScript | [GitHub](https://github.com/ankitsunil530/Weather-Knowing-System) | [Live](https://weather-knowing-system.vercel.app/) |
+| Fuzzy Logic Diabetes Diagnosis System | Python, Fuzzy Logic, Streamlit | [GitHub](https://github.com/ankitsunil530/Fuzzy-Project) | [Live](https://fuzzy-project.streamlit.app/) |
 
 ---
 
-# 💻 Academic / Full Stack Projects
-
-<div align="center">
-
-| 🚀 Project | ⚙️ Technologies | 🔗 GitHub Repository | 🌐 Live Demo |
-|---|---|---|---|
-| 📋 Task Management System | MERN, Redux Toolkit | [GitHub](https://github.com/ankitsunil530/Task-Management-System) | [Live](https://task-management-system-tawny-eta.vercel.app/) |
-| 🏦 Banking Website | React.js, Tailwind CSS | [GitHub](https://github.com/ankitsunil530/Banking-Website) | [Live](https://banking-website-gamma.vercel.app/) |
-| 🌦️ Weather Knowing System | HTML, CSS, JavaScript | [GitHub](https://github.com/ankitsunil530/Weather-Knowing-System) | [Live](https://weather-knowing-system.vercel.app/) |
-| 🧠 Fuzzy Logic Diabetes Diagnosis System | Python, Fuzzy Logic | [GitHub](https://github.com/ankitsunil530/Fuzzy-Project) | [Live](https://fuzzy-project.streamlit.app/) |
-
-</div>
+## Coding Profiles
+- [LeetCode](https://leetcode.com/ankitsunil530/)
+- [CodeChef](https://www.codechef.com/users/ankitsunil530)
+- [Codeforces](https://codeforces.com/profile/ankitsunil530)
 
 ---
 
-# 📊 GitHub Analytics
-
+## GitHub Stats
 <div align="center">
-
-<img height="180em" src="https://github-readme-stats.vercel.app/api?username=ankitsunil530&show_icons=true&theme=tokyonight&hide_border=true&count_private=true"/>
-
-<img height="180em" src="https://github-readme-streak-stats.herokuapp.com/?user=ankitsunil530&theme=tokyonight&hide_border=true"/>
-
-</div>
-
-<br/>
-
-<div align="center">
-
-<img width="95%" src="https://github-readme-activity-graph.vercel.app/graph?username=ankitsunil530&theme=tokyo-night&hide_border=true&area=true"/>
-
-</div>
-
----
-
-# 🧠 Competitive Programming
-
-<div align="center">
-
-<a href="https://leetcode.com/ankitsunil530/">
-<img src="https://leetcard.jacoblin.cool/ankitsunil530?theme=dark&font=Poppins&ext=contest"/>
-</a>
-
-<br/><br/>
-
-<a href="https://leetcode.com/ankitsunil530/">
-<img src="https://img.shields.io/badge/LeetCode-FFA116?style=for-the-badge&logo=leetcode&logoColor=white"/>
-</a>
-
-<a href="https://www.codechef.com/users/ankitsunil530">
-<img src="https://img.shields.io/badge/CodeChef-5B4638?style=for-the-badge&logo=codechef&logoColor=white"/>
-</a>
-
-<a href="https://codeforces.com/profile/ankitsunil530">
-<img src="https://img.shields.io/badge/Codeforces-1F8ACB?style=for-the-badge&logo=codeforces&logoColor=white"/>
-</a>
-
-</div>
-
----
-
-# 🏆 Achievements
-
-<div align="center">
-
-🥇 Solved **800+ DSA Problems** across coding platforms  
-
-🚀 Developed scalable MERN stack applications with authentication & APIs  
-
-🤖 Built AI/ML systems for medical image classification & healthcare prediction  
-
-⚡ Open Source Contributor – **GirlScript Summer of Code 2024**  
-
-💡 Experience with REST APIs, Deployment & Full Stack Architecture  
-
-</div>
-
----
-
-# 📚 Education
-
-<div align="center">
-
-🎓 **B.Tech in Computer Science & Engineering**  
-🏫 PDPM IIITDM Jabalpur  
-📅 2022 – 2026  
-
-</div>
-
----
-
-# 🌐 Connect With Me
-
-<div align="center">
-
-<a href="https://www.linkedin.com/in/sunil-kumar-549595225/">
-<img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white"/>
-</a>
-
-<a href="https://github.com/ankitsunil530">
-<img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white"/>
-</a>
-
-<a href="https://codolio.com/profile/ankitsunil530">
-<img src="https://img.shields.io/badge/Portfolio-111827?style=for-the-badge&logo=firefox&logoColor=white"/>
-</a>
-
-<a href="mailto:ankitsunil530@gmail.com">
-<img src="https://img.shields.io/badge/Gmail-EA4335?style=for-the-badge&logo=gmail&logoColor=white"/>
-</a>
-
+  <img height="170" src="https://github-readme-stats.vercel.app/api?username=ankitsunil530&show_icons=true&theme=tokyonight&hide_border=true&count_private=true"/>
+  <img height="170" src="https://github-readme-streak-stats.herokuapp.com/?user=ankitsunil530&theme=tokyonight&hide_border=true"/>
 </div>
 
 ---
 
 <div align="center">
 
-## ⚡ Code • Build • Learn • Repeat ⚡
-
-<img src="https://capsule-render.vercel.app/api?type=waving&height=140&section=footer&color=0:0F172A,50:1D4ED8,100:7C3AED"/>
+### Open to internships and full-time SDE opportunities.
 
 </div>
-
-<!-- Resume based updates from uploaded resume -->
-<!-- :contentReference[oaicite:0]{index=0} -->


### PR DESCRIPTION
### Motivation
- Make the GitHub profile README recruiter-friendly by replacing decorative elements with a concise professional header and clear sections. 
- Highlight only projects that have working live demos so visitors can quickly explore deployed work. 
- Improve scannability for hiring managers by adding a short summary, clear skills list, and compact project table. 

### Description
- Rewrote the hero/header to a simple name + role line and consolidated contact links into badges. 
- Added `Professional Summary` and `Technical Skills` sections with concise bullets for quick scanning. 
- Consolidated all project entries into a single `Projects (Live)` table and preserved only projects that include live demo URLs. 
- Removed excessive visual/animated elements and redundant sections while keeping coding profile links and GitHub stats. 

### Testing
- Verified changes via `git diff -- README.md` to confirm the content refactor. 
- Committed the change with `git commit` and confirmed the new commit (`git rev-parse --short HEAD` returned `1d726c0`). 
- Attempted automated live-link validation with `curl` which returned `000` for outbound requests due to the runtime environment network/DNS limitation, so links were preserved from profile data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c96725c8832ca9e64eb9b4cdd4ab)